### PR TITLE
docs(workspace): add initial readme for portfolio projects

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,0 +1,10 @@
+# Portfolio Projects
+
+## Overview
+
+This repository is a personal engineering portfolio showcasing projects in **backend development**, **data engineering**, and **cloud integration**. Each subdirectory contains a self-contained example that demonstrates skills in these domains, from building cloud-enabled APIs to performing data analysis on real-world datasets.
+
+## Projects
+
+* **`api/simple_aws_auth_with_rate_limit`** – A FastAPI-based REST API that integrates AWS Cognito for user authentication and enforces IP-based rate limiting. It uses AWS Secrets Manager and a MySQL database to persist user data, illustrating a combination of cloud identity services with application-level security controls.
+* **`data-processing/polars-example`** – A Jupyter Notebook demonstrating high-performance data processing using the Polars library. It analyzes a NYC taxi trips dataset (fetched via Kaggle) and correlates it with local weather data, showcasing efficient SQL-like queries, window functions, and data visualization with Plotly.


### PR DESCRIPTION
Added a new README file to describe the personal engineering portfolio, showcasing projects in backend development, data engineering, and cloud integration. This documentation serves as an introduction to the repository, detailing the contents and objectives of each project subdirectory.